### PR TITLE
Use --Form-message-font-size variable

### DIFF
--- a/lib/form.css
+++ b/lib/form.css
@@ -158,7 +158,7 @@
 .Form-message {
   color: var(--Form-message-color);
   display: block;
-  font-size: var(--Form-label-font-size);
+  font-size: var(--Form-message-font-size);
   font-weight: var(--Form-label-font-weight) \9;
   margin: 0;
 }


### PR DESCRIPTION
Make use of `--Form-message-font-size` which is declared and described in docs, but never used.

It's a breaking change. Currently, `.Form-message` font-size is set by `--Form-label-font-size` var.
